### PR TITLE
Update keymap, compatible with 34-key no mod-tap layout

### DIFF
--- a/config/boards/shields/pbgherkin/pbgherkin.keymap
+++ b/config/boards/shields/pbgherkin/pbgherkin.keymap
@@ -232,7 +232,7 @@
             bindings = <
     &kp CARET   &kp PRCNT   &kp PLUS    &kp LBKT    &kp COMMA   &kp SEMI    &kp RBKT    &kp EXCL    &kp TILDE   &kp GRAVE
     &kp DLLR    &kp EQUAL   &kp MINUS   &kp LPAR    &kp LT      &kp QT      &kp RPAR    &kp UNDER   &kp DQT     &kp SQT
-    &kp AT      &kp PIPE    &kp AMPS    &KP LBRC    &trans      &kp QMARK   &trans      &kp STAR    &kp HASH    &kp BSLH
+    &kp AT      &kp PIPE    &kp AMPS    &kp LBRC    &trans      &kp QMARK   &trans      &kp STAR    &kp HASH    &kp BSLH
             >;
         };
 

--- a/config/boards/shields/pbgherkin/pbgherkin.keymap
+++ b/config/boards/shields/pbgherkin/pbgherkin.keymap
@@ -60,7 +60,7 @@
 // |     |     |     |Keypd|Symbl|Keypd|Symbl|     |     |     |
 // -------------------------------------------------------------
             combo_symbl { timeout-ms = <50>; key-positions = <24 26>; bindings = <&mo SYMBL>; layers = <BASE QWRTY HNSDN SEMMK>; };
-            combo_keypd { timeout-ms = <50>; key-positions = <23 25>; bindings = <&kp KEYPD>; layers = <BASE QWRTY HNSDN SEMMK>; };
+            combo_keypd { timeout-ms = <50>; key-positions = <23 25>; bindings = <&mo KEYPD>; layers = <BASE QWRTY HNSDN SEMMK>; };
 
 // Colemak (Horizontal Combos)
 // -------------------------------------------------------------

--- a/config/boards/shields/pbgherkin/pbgherkin.keymap
+++ b/config/boards/shields/pbgherkin/pbgherkin.keymap
@@ -13,12 +13,14 @@
 
 #define BASE  0     // alphas (Colemak-DH)
 #define QWRTY 1     // alphas (Qwerty)
-#define HNSDN 2     // alphas (Hands Down Neu)
-#define SYMBL 3     // symbols
-#define LOWER 4     // functions & numbers
-#define RAISE 5     // keypad & navigation
-#define MEDIA 6     // functions2 & multimedia
-#define ADJST 7     // lighting & bluetooth
+#define HNSDN 2     // alphas (Hands Down Neu 30)
+$define SEMMK 3     // alphas (Semimak JQ)
+#define RAISE 4     // symbols & numbers
+#define SYMBL 5     // symbols
+#define LOWER 6     // functions & navigation
+#define KEYPD 7     // functions2 & keypad
+#define MODS  8     // modifiers & multimedia
+#define ADJST 9     // lighting & bluetooth
 
 // Special keys
 #define ZOOMOUT      LA(LG(MINUS))
@@ -38,11 +40,9 @@
     flavor = "balanced";
 };
 
-&mt {
-    tapping-term-ms = <200>;
-    quick_tap_ms = <200>;
-    flavor = "balanced";
-};
+&sk {
+    release-after-ms = <2000>;
+}
 
 &caps_word {
     continue-list = <UNDERSCORE BACKSPACE DELETE MINUS DOT>;
@@ -50,72 +50,56 @@
 
 / {
     behaviors {
-        hm: homerow_mods {
-            compatible = "zmk,behavior-hold-tap";
-            label = "HOMEROW_MODS";
-            #binding-cells = <2>;
-            flavor = "tap-preferred";
-            tapping-term-ms = <200>;
-            quick-tap-ms = <200>;
-            bindings = <&kp>, <&kp>;
-        };
-
-        ph: positional_hold_tap {
-            compatible = "zmk,behavior-hold-tap";
-            label = "POSITIONAL_HOLD_TAP";
-            #binding-cells = <2>;
-            flavor = "tap-preferred";
-            tapping-term-ms = <200>;
-            quick-tap-ms = <200>;
-            bindings = <&kp>, <&kp>;
-            hold-trigger-key-positions = < 5  6  7  8  9
-                                          15 16 17 18 19
-                                                27 28 29>;
-        };
-
-        th: thumb_hold_tap {
-            compatible = "zmk,behavior-hold-tap";
-            label = "THUMB_HOLD_TAP";
-            #binding-cells = <2>;
-            flavor = "balanced";
-            tapping-term-ms = <200>;
-            quick-tap-ms = <0>;         // no key repeat
-            bindings = <&mo>, <&kp>;
-        };
-
         combos {
             compatible = "zmk,combos";
 
 // Colemak (Horizontal Combos)
 // -------------------------------------------------------------
-// |     |<-  Esc  ->|     |     |     |     |     |     |     |
+// |     |<-  Esc  ->|     |     |     |     |<- BkSpc ->|     |
 // |     |     |     |<-   V   ->|<-   K   ->|     |     |     |
-// |     |<-  Tab  ->|<- Bkspc ->|<- Space ->|<- Enter ->|     |
+// |     |<-  Tab  ->|     |     |     |     |<- Enter ->|     |
 // -------------------------------------------------------------
-            combo_esc   { timeout-ms = <50>; key-positions = < 1  2>; bindings = <&kp ESC>;   layers = <BASE QWRTY HNSDN SYMBL>; };
-            combo_tab   { timeout-ms = <50>; key-positions = <21 22>; bindings = <&kp TAB>;   layers = <BASE QWRTY HNSDN SYMBL>; };
-            combo_bspc  { timeout-ms = <50>; key-positions = <23 24>; bindings = <&kp BSPC>;  layers = <BASE QWRTY HNSDN SYMBL>; };
-            combo_space { timeout-ms = <50>; key-positions = <25 26>; bindings = <&kp SPACE>; layers = <BASE QWRTY HNSDN SYMBL>; };
-            combo_enter { timeout-ms = <50>; key-positions = <27 28>; bindings = <&kp ENTER>; layers = <BASE QWRTY HNSDN SYMBL>; };
+            combo_esc   { timeout-ms = <50>; key-positions = < 1  2>; bindings = <&kp ESC>;   layers = <BASE QWRTY HNSDN SEMMK>; };
+            combo_tab   { timeout-ms = <50>; key-positions = <21 22>; bindings = <&kp TAB>;   layers = <BASE QWRTY HNSDN SEMMK>; };
+            combo_bspc  { timeout-ms = <50>; key-positions = <17 18>; bindings = <&kp BSPC>;  layers = <BASE QWRTY HNSDN SEMMK>; };
+            combo_enter { timeout-ms = <50>; key-positions = <27 28>; bindings = <&kp ENTER>; layers = <BASE QWRTY HNSDN SEMMK>; };
             combo_v     { timeout-ms = <50>; key-positions = <13 14>; bindings = <&kp V>;     layers = <BASE>; };
             combo_k     { timeout-ms = <50>; key-positions = <15 16>; bindings = <&kp K>;     layers = <BASE>; };
 
 // Qwerty (Horizontal Combos)
 // -------------------------------------------------------------
-// |     |<-  Esc  ->|     |     |     |     |     |     |     |
+// |     |<-  Esc  ->|     |     |     |     |<- BkSpc ->|     |
 // |     |     |     |<-   B   ->|<-   N   ->|     |     |     |
-// |     |<-  Tab  ->|<- Bkspc ->|<- Space ->|<- Enter ->|     |
+// |     |<-  Tab  ->|     |     |     |     |<- Enter ->|     |
 // -------------------------------------------------------------
             combo_b     { timeout-ms = <50>; key-positions = <13 14>; bindings = <&kp B>;     layers = <QWRTY HNSDN>; };
             combo_n     { timeout-ms = <50>; key-positions = <15 16>; bindings = <&kp N>;     layers = <QWRTY>; };
 
 // Hands Down Neu 30 (Horizontal Combos)
 // -------------------------------------------------------------
-// |     |<-  Esc  ->|     |     |     |     |     |     |     |
+// |     |<-  Esc  ->|     |     |     |     |<- Bkspc ->|     |
 // |     |     |     |<-   B   ->|<-   ;   ->|     |     |     |
-// |     |<-  Tab  ->|<- Bkspc ->|<- Space ->|<- Enter ->|     |
+// |     |<-  Tab  ->|     |     |     |     |<- Enter ->|     |
 // -------------------------------------------------------------
             combo_semi  { timeout-ms = <50>; key-positions = <15 16>; bindings = <&kp SEMI>;  layers = <HNSDN>; };
+
+// Semimak JQ (Horizontal Combos)
+// -------------------------------------------------------------
+// |     |<-  Esc  ->|     |     |     |     |<- Bkspc ->|     |
+// |     |     |     |<-   Q   ->|<-   P   ->|     |     |     |
+// |     |<-  Tab  ->|     |     |     |     |<- Enter ->|     |
+// -------------------------------------------------------------
+            combo_q     { timeout-ms = <50>; key-positions = <13 14>; bindings = <&kp Q>;     layers = <SEMMK>; };
+            combo_p     { timeout-ms = <50>; key-positions = <15 16>; bindings = <&kp P>;     layers = <SEMMK>; };
+
+// Symbols & Numbers (Horizontal Combos)
+// -------------------------------------------------------------
+// |     |     |     |     |     |     |     |     |     |     |
+// |     |     |     |<-   {   ->|<-   }   ->|     |     |     |
+// |     |     |     |     |     |     |     |     |     |     |
+// -------------------------------------------------------------
+            combo_lbrc  { timeout-ms = <50>; key-positions = <13 14>; bindings = <&kp LBRC>;  layers = <RAISE>; };
+            combo_rbrc  { timeout-ms = <50>; key-positions = <15 16>; bindings = <&kp RBRC>;  layers = <RAISE>; };
 
 // Symbols (Horizontal Combos)
 // -------------------------------------------------------------
@@ -128,34 +112,21 @@
 
 // Functions & Numbers (Horizontal Combos)
 // -------------------------------------------------------------
-// |     |     |     |     |     |<-   *   ->|     |     |     |
-// |     |     |     |<-  F12  ->|<-   :   ->|     |     |     |
+// |     |     |     |     |     |     |     |     |     |     |
+// |     |     |     |<-  F12  ->|     |     |     |     |     |
 // |     |     |     |     |     |     |     |     |     |     |
 // -------------------------------------------------------------
             combo_f12   { timeout-ms = <50>; key-positions = <13 14>; bindings = <&kp F12>;   layers = <LOWER>; };
-            combo_star  { timeout-ms = <50>; key-positions = < 5  6>; bindings = <&kp STAR>;  layers = <LOWER>; };
-            combo_colon { timeout-ms = <50>; key-positions = <15 16>; bindings = <&kp COLON>; layers = <LOWER>; };
 
 // Keypad & Navigation (Horizontal Combos)
 // -------------------------------------------------------------
-// |     |     |     |<- NumLk ->|     |    Zm-   Zm+    |     |
-// |     |     |     |<-   *   ->|     |     |     |     |     |
+// |     |     |     |     |     |<- NumLk ->|     |     |     |
+// |     |     |     |<-  F24  ->|<-   -   ->|     |     |     |
 // |     |     |     |     |     |     |     |     |     |     |
 // -------------------------------------------------------------
-            combo_kpnum { timeout-ms = <50>; key-positions = < 3  4>; bindings = <&kp KP_NUM>;      layers = <RAISE>; };
-            combo_kpmul { timeout-ms = <50>; key-positions = <13 14>; bindings = <&kp KP_MULTIPLY>; layers = <RAISE>; };
-            combo_zmout { timeout-ms = <50>; key-positions = < 6  7>; bindings = <&kp ZOOMOUT>;     layers = <RAISE>; };
-            combo_zmin  { timeout-ms = <50>; key-positions = < 7  8>; bindings = <&kp ZOOMIN>;      layers = <RAISE>; };
-
-// Functions2 & Multimedia (Horizontal Combos)
-// -------------------------------------------------------------
-// |     |     |     |     |     |     |     |     |     |     |
-// |     |     |     |<- ScrLk ->|<- Prev  ->|     |     |     |
-// |     |     |     |     |     |     |     |     |     |     |
-// -------------------------------------------------------------
-            combo_slck  { timeout-ms = <50>; key-positions = <13 14>; bindings = <&kp SLCK>;    layers = <MEDIA>; };
-            combo_prev  { timeout-ms = <50>; key-positions = <15 16>; bindings = <&kp C_PREV>;  layers = <MEDIA>; };
-
+            combo_kpnum { timeout-ms = <50>; key-positions = < 5  6>; bindings = <&kp KP_NUM>;    layers = <KEYPD>; };
+            combo_kpmin { timeout-ms = <50>; key-positions = <15 16>; bindings = <&kp KP_MINUS>;  layers = <KEYPD>; };
+            combo_f24   { timeout-ms = <50>; key-positions = <13 14>; bindings = <&kp F24>;       layers = <KEYPD>; };
 
 // Bluetooth & RGB (Horizontal Combos)
 // -------------------------------------------------------------
@@ -179,19 +150,19 @@
 // (Hold)
 // -------------------------------------------------------------
 // |     |     |     |     |     |     |     |     |     |     |
-// |LCtrl| LAlt| LGui|Shift|     |     |Shift| RGui| RAlt|RCtrl|
-// |     |     |     |LOWER|LShft|SYMBL|RAISE|     |     |     |
+// |     |     |     |     |     |     |     |     |     |     |
+// |     |     |     |LOWER|     |     |RAISE|     |     |     |
 // -------------------------------------------------------------
 // Colemak-DH
 // -------------------------------------------------------------
 // |  Q  |  W  |  F  |  P  |  B  |  J  |  L  |  U  |  Y  |  ;  |
 // |  A  |  R  |  S  |  T  |  G  |  M  |  N  |  E  |  I  |  O  |
-// |  Z  |  X  |  C  |  D  |BkSpc|Space|  H  |  ,  |  .  |  /  |
+// |  Z  |  X  |  C  |  D  |LSft |Space|  H  |  ,  |  .  |  /  |
 // -------------------------------------------------------------
             bindings = < 
     &kp Q       &kp W       &kp F       &kp P       &kp B         &kp J           &kp L       &kp U       &kp Y       &kp SEMI
-    &hm LCTRL A &hm LALT R  &hm LGUI S  &hm LSFT T  &kp G         &kp M           &hm RSFT N  &hm RGUI E  &hm RALT I  &hm RCTRL O
-    &kp Z       &kp X       &kp C       &lt LOWER D &mt LSFT BSPC &th SYMBL SPACE &lt RAISE H &kp COMMA   &kp DOT     &kp FSLH
+    &kp A       &kp R       &kp S       &kp T       &kp G         &kp M           &kp N       &kp E       &kp I       &kp O
+    &kp Z       &kp X       &kp C       &lt LOWER D &kp LSFT      &kp SPACE       &lt RAISE H &kp COMMA   &kp DOT     &kp FSLH
             >;
         } ;
 
@@ -200,7 +171,7 @@
 // -------------------------------------------------------------
 // |  Q  |  W  |  E  |  R  |  T  |  Y  |  U  |  I  |  O  |  P  |
 // |  A  |  S  |  D  |  F  |  G  |  H  |  J  |  K  |  L  |  ;  |
-// |  Z  |  X  |  C  |  V  |BkSpc|Space|  M  |  ,  |  .  |  /  |
+// |  Z  |  X  |  C  |  V  |LSft |Space|  M  |  ,  |  .  |  /  |
 // -------------------------------------------------------------
             bindings = < 
     &kp Q       &kp W       &kp E       &kp R       &kp T         &kp Y           &kp U       &kp I       &kp O       &kp P
@@ -209,12 +180,12 @@
             >;
         } ;
 
-        handsdownneu_layer {
-// Hands Down New 30
+        handsdownneu30_layer {
+// Hands Down Neu 30
 // -------------------------------------------------------------
 // |  W  |  F  |  M  |  P  |  V  |  /  |  .  |  Q  |  J  |  Z  |
 // |  R  |  S  |  N  |  T  |  G  |  ,  |  A  |  E  |  I  |  H  |
-// |  X  |  C  |  L  |  D  |BkSpc|Space|  U  |  O  |  Y  |  K  |
+// |  X  |  C  |  L  |  D  |LSft |Space|  U  |  O  |  Y  |  K  |
 // -------------------------------------------------------------
             bindings = < 
     &kp W       &kp F       &kp M       &kp P       &kp V         &kp FSLH        &kp DOT     &kp Q       &kp J       &kp Z
@@ -223,72 +194,98 @@
             >;
         } ;
 
+        semimakjq_layer {
+// Semimak JQ
+// -------------------------------------------------------------
+// |  F  |  L  |  H  |  V  |  Z  |  ;  |  W  |  U  |  O  |  Y  |
+// |  S  |  R  |  N  |  T  |  K  |  C  |  D  |  E  |  A  |  I  |
+// |  X  |  J  |  B  |  M  |LSft |Space|  G  |  ,  |  .  |  /  |
+// -------------------------------------------------------------
+            bindings = < 
+    &kp F       &kp L       &kp H       &kp V       &kp Z         &kp SEMI        &kp W       &kp U       &kp O       &kp Y
+    &kp S       &kp R       &kp N       &kp T       &kp K         &kp C           &kp D       &kp E       &kp A       &kp O
+    &kp X       &kp J       &kp B       &lt LOWER M &kp LSFT      &kp SPACE       &lt RAISE G &kp COMMA   &kp DOT     &kp FSLH
+            >;
+        } ;
+
+        symbols_numbers_layer {
+// symbols & numbers
+// -------------------------------------------------------------
+// |  9  |  5  |  3  |  1  |  7  |  6  |  0  |  2  |  4  |  8  |
+// |  $  |  =  |  -  |  (  |  .  |  :  |  )  |  _  |  "  |  '  |
+// |  @  |  |  |  &  |  {  |  [  |  ]  | *** |  *  |  #  |  \  |
+// -------------------------------------------------------------
+            bindings = <
+    &kp N9      &kp N5      &kp N3      &kp N1          &kp N7          &kp N6      &kp N0      &kp N2      &kp N4      &kp N8
+    &kp DLLR    &kp EQUAL   &kp MINUS   &kp LPAR        &kp DOT         &kp COLON   &kp RPAR    &kp UNDER   &kp DQT     &kp SQT
+    &kp AT      &kp PIPE    &kp AMPS    &lt MODS LBRC   &lt SYMBL LBKT  &kp RBKT    &trans      &kp STAR    &kp HASH    &kp BSLH
+            >;
+        };
+
         symbols_layer {
 // symbols
 // -------------------------------------------------------------
-// |  ~  |  |  |  &  |  [  |  ;  |  :  |  ]  |  "  |  '  |  `  |
-// |  $  |  =  |  -  |  (  |  <  |  >  |  )  |  _  |  *  |  #  |
-// |  !  |  %  |  +  |  {  | Del | *** |  }  |  \  |  @  |  ^  |
+// |  ^  |  %  |  +  |  [  |  ,  |  ;  |  ]  |  !  |  ~  |  `  |
+// |  $  |  =  |  -  |  (  |  <  |  >  |  )  |  _  |  "  |  '  |
+// |  @  |  |  |  &  |  {  | *** |  ?  | *** |  *  |  #  |  \  |
 // -------------------------------------------------------------
             bindings = <
-    &kp TILDE   &kp PIPE    &kp AMPS    &kp LBKT    &kp SEMI      &kp COLON   &kp RBKT    &kp DQT     &kp SQT     &kp GRAVE 
-    &kp DLLR    &kp EQUAL   &kp MINUS   &kp LPAR    &kp LT        &kp GT      &kp RPAR    &kp UNDER   &kp STAR    &kp HASH
-    &kp EXCL    &kp PRCNT   &kp PLUS    &kp LBRC    &lt MEDIA DEL &trans      &kp RBRC    &kp BSLH    &kp AT      &kp CARET
+    &kp CARET   &kp PRCNT   &kp PLUS    &kp LBKT    &kp COMMA   &kp SEMI    &kp RBKT    &kp EXCL    &kp TILDE   &kp GRAVE
+    &kp DLLR    &kp EQUAL   &kp MINUS   &kp LPAR    &kp LT      &kp QT      &kp RPAR    &kp UNDER   &kp DQT     &kp SQT
+    &kp AT      &kp PIPE    &kp AMPS    &KP LBRC    &trans      &kp QMARK   &trans      &kp STAR    &kp HASH    &kp BSLH
             >;
         };
 
-        lower_layer {
-// functions & numbers
+        functions_navigation_layer {
+// functions & navigation
 // -------------------------------------------------------------
-// | F1  | F2  | F3  | F4  |Pause|  =  |  7  |  8  |  9  |  /  |
-// | F5  | F6  | F7  | F8  |PrnSc|  -  |  4  |  5  |  6  |  +  |
-// | F9  | F10 | F11 | *** |ScrLk|  0  |  1  |  2  |  3  |  .  |
+// | F1  | F2  | F3  | F4  |Pause| Ins |PgUp | Up  |PgDn |Menu |
+// | F5  | F6  | F7  | F8  |PrnSc|Home |Left |Down |Right| End |
+// | F9  | F10 | F11 | *** |ScrLk| Tab |BkSpc|Enter| Del |     |
 // -------------------------------------------------------------
             bindings = <
-    &kp F1       &kp F2       &kp F3       &kp F4       &kp PAUSE_BREAK &kp EQUAL    &kp N7       &kp N8       &kp N9       &kp FSLH
-    &hm LCTRL F5 &hm LALT F6  &hm LGUI F7  &hm LSFT F8  &kp PSCRN       &kp MINUS    &hm RSFT N4  &hm RGUI N5  &hm RALT N6  &hm RCTRL PLUS
-    &kp F9       &kp F10      &kp F11      &trans       &kp SLCK        &kp N0       &lt ADJST N1 &kp N2       &kp N3       &kp DOT
+    &kp F1      &kp F2      &kp F3      &kp F4      &kp PAUSE_BREAK &kp INS       &kp PG_UP     &kp UP      &kp PG_DN   &kp K_APP
+    &kp F5      &kp F6      &kp F7      &kp F8      &kp PSCRN       &kp HOME      &kp LEFT      &kp DOWN    &kp RIGHT   &kp END
+    &kp F9      &kp F10     &kp F11     &trans      &kp SLCK        &lt KEYPD TAB &lt MODS BSPC &kp ENTER   &kp DEL     &none
             >;
         };
 
-        raise_layer {
-// keypad & navigation
+        functions2_keypad_layer {
+// functions & navigation
 // -------------------------------------------------------------
-// |  /  |  7  |  8  |  9  |  =  | Ins |PgUp | Up  |PgDn | Del |
-// |  +  |  4  |  5  |  6  |  -  |Home |Left |Down |Right| End |
-// |  .  |  1  |  2  |  3  |  0  |Enter| *** |CapWd|CapLk|Menu |
+// | F13 | F14 | F15 | F16 |  =  |  *  |  7  |  8  |  9  |  /  |
+// | F17 | F18 | F19 | F20 |  -  |  0  |  4  |  5  |  6  |  +  |
+// | F21 | F22 | F23 | *** |     | *** |  1  |  2  |  3  |  .  |
 // -------------------------------------------------------------
             bindings = <
-    &kp KP_DIVIDE     &kp KP_N7      &kp KP_N8      &kp KP_N9       &kp KP_EQUAL &kp INS      &kp PG_UP   &kp UP     &kp PG_DN  &kp DEL
-    &ph LCTRL KP_PLUS &ph LALT KP_N4 &ph LGUI KP_N5 &ph LSFT KP_N6  &kp KP_MINUS &kp HOME     &kp LEFT    &kp DOWN   &kp RIGHT  &kp END
-    &kp KP_DOT        &kp KP_N1      &kp KP_N2      &lt ADJST KP_N3 &kp KP_N0    &kp KP_ENTER &trans      &caps_word &kp CAPS   &kp K_APP
+    &kp F13     &kp F14     &kp F15     &kp F16     &kp KP_EQUAL  &kp KP_MULTIPLY &kp KP_N7     &kp KP_N8   &kp KP_N9   &kp KP_DIVIDE
+    &kp F17     &kp F18     &kp F19     &kp F20     &kp KP_MINUS  &kp KP_N0       &kp KP_N4     &kp KP_N5   &kp KP_N6   &kp KP_PLUS
+    &kp F21     &kp F22     &kp F23     &trans      &none         &trans          &kp KP_N1     &kp KP_N2   &kp KP_N3   &kp KP_DOT
             >;
         };
 
-        media_layer {
-// Functions2 & Multimedia
+        modifiers_layer {
 // -------------------------------------------------------------
-// | F13 | F14 | F15 | F16 |Pause|AlWin|Files| WWW |Calc |     |
-// | F17 | F18 | F19 | F20 |PrnSc|AlApp|Vol- |Mute |Vol+ |Eject|
-// | F21 | F22 | F23 | F24 | *** | *** |Rewnd|Play |FFwd |Next |
+// | Esc |     |Zoom-|Zoom+|Mouse|Adjst|Vol- |Mute |Vol+ |Eject|
+// |Ctrl | Alt | Cmd |Shift|CapLk|CapWd|Shift| Cmd | Alt |Ctrl |
+// |Undo | Cut |Copy | *** |Paste|SelAl| *** |Prev |Play |Next |
 // -------------------------------------------------------------
             bindings = <
-    &kp F13      &kp F14      &kp F15      &kp F16      &kp PAUSE_BREAK &kp C_AC_DESKTOP_SHOW_ALL_WINDOWS      &kp C_AL_FILES    &kp C_AL_WWW    &kp C_AL_CALC     &trans      
-    &kp F17      &kp F18      &kp F19      &kp F20      &kp PSCRN       &kp C_AC_DESKTOP_SHOW_ALL_APPLICATIONS &hm RSFT C_VOL_DN &hm RGUI C_MUTE &hm RALT C_VOL_UP &hm RCTRL C_EJECT
-    &kp F21      &kp F22      &kp F23      &kp F24      &trans          &trans                                 &kp C_RW          &kp C_PP        &kp C_FF          &kp C_NEXT
+    &kp ESC     &none       &kp ZOOMOUT &kp ZOOMIN  &none       &tog ADJST    &kp C_VOL_DN  &kp C_MUTE    &kp C_VOL_UP  &kp C_EJECT
+    &sk LCTRL   &sk LALT    &sk LGUI    &sk LSHFT   &kp CAPS    &caps_word    &sk RSHFT     &sk RGUI      &sk RALT      &sk RCTRL
+    &kp M_UNDO  &kp M_CUT   &kp M_COPY  &trans      &kp M_PASTE &kp M_SELALL  &trans        &kp C_PREV    &kp C_PP      &kp C_NEXT
             >;
-        };
 
         adjust_layer {
 // -------------------------------------------------------------
 // |Bri+ |     |     |     |Toggl|BTClr| BT0 | BT1 | BT2 | BT3 |
-// |Bri- |     |     |     |     |     |Colmk|Qwrty|HnsDn|     |
+// |Bri- |     |     |     |     |     |Colmk|Qwrty|HnsDn|Semmk|
 // | USB | BLE |     | *** |     |     | *** |     |Reset|BootL|
 // -------------------------------------------------------------
             bindings = <
-    &bl BL_INC   &none        &none   &none   &bl BL_TOG &bt BT_CLR &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3
-    &bl BL_DEC   &none        &none   &none   &none      &none      &to BASE     &to QWRTY    &to HNSDN    &none
-    &out OUT_USB &out OUT_BLE &none   &trans  &none      &none      &trans       &none        &reset       &bootloader
+    &bl BL_INC    &none         &none   &none   &bl BL_TOG  &bt BT_CLR  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3
+    &bl BL_DEC    &none         &none   &none   &none       &none       &to BASE      &to QWRTY     &to HNSDN     &to SEMMK
+    &out OUT_USB  &out OUT_BLE  &none   &trans  &tog ADJST  &tog ADJST  &trans        &none         &reset        &bootloader
             >;
 /*
 //  v----------- RGB -----------v

--- a/config/boards/shields/pbgherkin/pbgherkin.keymap
+++ b/config/boards/shields/pbgherkin/pbgherkin.keymap
@@ -175,8 +175,8 @@
 // -------------------------------------------------------------
             bindings = < 
     &kp Q       &kp W       &kp E       &kp R       &kp T         &kp Y           &kp U       &kp I       &kp O       &kp P
-    &hm LCTRL A &hm LALT S  &hm LGUI D  &hm LSFT F  &kp G         &kp H           &hm RSFT J  &hm RGUI K  &hm RALT L  &hm RCTRL SEMI
-    &kp Z       &kp X       &kp C       &lt LOWER V &mt LSFT BSPC &th SYMBL SPACE &lt RAISE M &kp COMMA   &kp DOT     &kp FSLH
+    &kp A       &kp S       &kp D       &kp F       &kp G         &kp H           &kp J       &kp K       &kp L       &kp SEMI
+    &kp Z       &kp X       &kp C       &lt LOWER V &kp LSFT      &kp SPACE       &lt RAISE M &kp COMMA   &kp DOT     &kp FSLH
             >;
         } ;
 
@@ -189,8 +189,8 @@
 // -------------------------------------------------------------
             bindings = < 
     &kp W       &kp F       &kp M       &kp P       &kp V         &kp FSLH        &kp DOT     &kp Q       &kp J       &kp Z
-    &hm LCTRL R &hm LALT S  &hm LGUI N  &hm LSFT T  &kp G         &kp COMMA       &hm RSFT A  &hm RGUI E  &hm RALT I  &hm RCTRL H
-    &kp X       &kp C       &kp L       &lt LOWER D &mt LSFT BSPC &th SYMBL SPACE &lt RAISE U &kp O       &kp Y       &kp K
+    &kp R       &kp S       &kp N       &kp T       &kp G         &kp COMMA       &kp A       &kp E       &kp I       &kp H
+    &kp X       &kp C       &kp L       &lt LOWER D &kp LSFT      &kp SPACE       &lt RAISE U &kp O       &kp Y       &kp K
             >;
         } ;
 

--- a/config/boards/shields/pbgherkin/pbgherkin.keymap
+++ b/config/boards/shields/pbgherkin/pbgherkin.keymap
@@ -53,6 +53,15 @@
         combos {
             compatible = "zmk,combos";
 
+// Layers (Horizontal Combos)
+// -------------------------------------------------------------
+// |     |     |     |     |     |     |     |     |     |     |
+// |     |     |     |     |     |     |     |     |     |     |
+// |     |     |     |Keypd|Symbl|Keypd|Symbl|     |     |     |
+// -------------------------------------------------------------
+            combo_symbl { timeout-ms = <50>; key-positions = <24 26>; bindings = <&mo SYMBL>; layers = <BASE QWRTY HNSDN SEMMK>; };
+            combo_keypd { timeout-ms = <50>; key-positions = <23 25>; bindings = <&kp KEYPD>; layers = <BASE QWRTY HNSDN SEMMK>; };
+
 // Colemak (Horizontal Combos)
 // -------------------------------------------------------------
 // |     |<-  Esc  ->|     |     |     |     |<- BkSpc ->|     |

--- a/config/boards/shields/pbgherkin/pbgherkin.keymap
+++ b/config/boards/shields/pbgherkin/pbgherkin.keymap
@@ -275,6 +275,7 @@
     &sk LCTRL   &sk LALT    &sk LGUI    &sk LSHFT   &kp CAPS    &caps_word    &sk RSHFT     &sk RGUI      &sk RALT      &sk RCTRL
     &kp M_UNDO  &kp M_CUT   &kp M_COPY  &trans      &kp M_PASTE &kp M_SELALL  &trans        &kp C_PREV    &kp C_PP      &kp C_NEXT
             >;
+        };
 
         adjust_layer {
 // -------------------------------------------------------------

--- a/config/boards/shields/pbgherkin/pbgherkin.keymap
+++ b/config/boards/shields/pbgherkin/pbgherkin.keymap
@@ -61,7 +61,7 @@
 // -------------------------------------------------------------
             combo_esc   { timeout-ms = <50>; key-positions = < 1  2>; bindings = <&kp ESC>;   layers = <BASE QWRTY HNSDN SEMMK>; };
             combo_tab   { timeout-ms = <50>; key-positions = <21 22>; bindings = <&kp TAB>;   layers = <BASE QWRTY HNSDN SEMMK>; };
-            combo_bspc  { timeout-ms = <50>; key-positions = <17 18>; bindings = <&kp BSPC>;  layers = <BASE QWRTY HNSDN SEMMK>; };
+            combo_bspc  { timeout-ms = <50>; key-positions = < 7  8>; bindings = <&kp BSPC>;  layers = <BASE QWRTY HNSDN SEMMK>; };
             combo_enter { timeout-ms = <50>; key-positions = <27 28>; bindings = <&kp ENTER>; layers = <BASE QWRTY HNSDN SEMMK>; };
             combo_v     { timeout-ms = <50>; key-positions = <13 14>; bindings = <&kp V>;     layers = <BASE>; };
             combo_k     { timeout-ms = <50>; key-positions = <15 16>; bindings = <&kp K>;     layers = <BASE>; };
@@ -96,7 +96,7 @@
 // -------------------------------------------------------------
 // |     |     |     |     |     |     |     |     |     |     |
 // |     |     |     |<-   {   ->|<-   }   ->|     |     |     |
-// |     |     |     |     |     |     |     |     |     |     |
+// |     |     |     |     |     |     | *** |     |     |     |
 // -------------------------------------------------------------
             combo_lbrc  { timeout-ms = <50>; key-positions = <13 14>; bindings = <&kp LBRC>;  layers = <RAISE>; };
             combo_rbrc  { timeout-ms = <50>; key-positions = <15 16>; bindings = <&kp RBRC>;  layers = <RAISE>; };
@@ -105,7 +105,7 @@
 // -------------------------------------------------------------
 // |     |     |     |     |     |     |     |     |     |     |
 // |     |     |     |<-   /   ->|<-   ?   ->|     |     |     |
-// |     |     |     |     |     |     |     |     |     |     |
+// |     |     |     |     | *** |     | *** |     |     |     |
 // -------------------------------------------------------------
             combo_fslh  { timeout-ms = <50>; key-positions = <13 14>; bindings = <&kp FSLH>;  layers = <SYMBL>; };
             combo_qmark { timeout-ms = <50>; key-positions = <15 16>; bindings = <&kp QMARK>; layers = <SYMBL>; };
@@ -113,20 +113,22 @@
 // Functions & Numbers (Horizontal Combos)
 // -------------------------------------------------------------
 // |     |     |     |     |     |     |     |     |     |     |
-// |     |     |     |<-  F12  ->|     |     |     |     |     |
-// |     |     |     |     |     |     |     |     |     |     |
+// |     |     |     |<-  F12  ->|<-  Tab  ->|     |     |     |
+// |     |     |     | *** |     |     |     |     |     |     |
 // -------------------------------------------------------------
             combo_f12   { timeout-ms = <50>; key-positions = <13 14>; bindings = <&kp F12>;   layers = <LOWER>; };
+            combo_tab   { timeout-ms = <50>; key-positions = <15 16>; bindings = <&kp TAB>;   layers = <LOWER>; };
 
-// Keypad & Navigation (Horizontal Combos)
+// Functions & Keypad (Horizontal Combos)
 // -------------------------------------------------------------
-// |     |     |     |     |     |<- NumLk ->|     |     |     |
+// |     |     |     |     |     |<-   =   ->|     |     |     |
 // |     |     |     |<-  F24  ->|<-   -   ->|     |     |     |
-// |     |     |     |     |     |     |     |     |     |     |
+// |     |     |     | *** |     | *** |     |<- Enter ->|     |
 // -------------------------------------------------------------
-            combo_kpnum { timeout-ms = <50>; key-positions = < 5  6>; bindings = <&kp KP_NUM>;    layers = <KEYPD>; };
-            combo_kpmin { timeout-ms = <50>; key-positions = <15 16>; bindings = <&kp KP_MINUS>;  layers = <KEYPD>; };
             combo_f24   { timeout-ms = <50>; key-positions = <13 14>; bindings = <&kp F24>;       layers = <KEYPD>; };
+            combo_kpeql { timeout-ms = <50>; key-positions = < 5  6>; bindings = <&kp KP_EQUAL>;  layers = <KEYPD>; };
+            combo_kpmin { timeout-ms = <50>; key-positions = <15 16>; bindings = <&kp KP_MINUS>;  layers = <KEYPD>; };
+            combo_kpent { timeout-ms = <50>; key-positions = <27 28>; bindings = <&kp KP_ENTER>;  layers = <KEYPD>; };
 
 // Bluetooth & RGB (Horizontal Combos)
 // -------------------------------------------------------------
@@ -251,14 +253,14 @@
         };
 
         functions2_keypad_layer {
-// functions & navigation
+// functions & keypad
 // -------------------------------------------------------------
-// | F13 | F14 | F15 | F16 |  =  |  *  |  7  |  8  |  9  |  /  |
+// | F13 | F14 | F15 | F16 |NumLk|  *  |  7  |  8  |  9  |  /  |
 // | F17 | F18 | F19 | F20 |  -  |  0  |  4  |  5  |  6  |  +  |
 // | F21 | F22 | F23 | *** |     | *** |  1  |  2  |  3  |  .  |
 // -------------------------------------------------------------
             bindings = <
-    &kp F13     &kp F14     &kp F15     &kp F16     &kp KP_EQUAL  &kp KP_MULTIPLY &kp KP_N7     &kp KP_N8   &kp KP_N9   &kp KP_DIVIDE
+    &kp F13     &kp F14     &kp F15     &kp F16     &kp KP_NUM    &kp KP_MULTIPLY &kp KP_N7     &kp KP_N8   &kp KP_N9   &kp KP_DIVIDE
     &kp F17     &kp F18     &kp F19     &kp F20     &kp KP_MINUS  &kp KP_N0       &kp KP_N4     &kp KP_N5   &kp KP_N6   &kp KP_PLUS
     &kp F21     &kp F22     &kp F23     &trans      &none         &trans          &kp KP_N1     &kp KP_N2   &kp KP_N3   &kp KP_DOT
             >;

--- a/config/boards/shields/pbgherkin/pbgherkin.keymap
+++ b/config/boards/shields/pbgherkin/pbgherkin.keymap
@@ -41,7 +41,7 @@
 };
 
 &sk {
-    release-after-ms = <2000>;
+    release-after-ms = <3000>;
 };
 
 &caps_word {

--- a/config/boards/shields/pbgherkin/pbgherkin.keymap
+++ b/config/boards/shields/pbgherkin/pbgherkin.keymap
@@ -117,7 +117,7 @@
 // |     |     |     | *** |     |     |     |     |     |     |
 // -------------------------------------------------------------
             combo_f12   { timeout-ms = <50>; key-positions = <13 14>; bindings = <&kp F12>;   layers = <LOWER>; };
-            combo_tab   { timeout-ms = <50>; key-positions = <15 16>; bindings = <&kp TAB>;   layers = <LOWER>; };
+            combo_tab2  { timeout-ms = <50>; key-positions = <15 16>; bindings = <&kp TAB>;   layers = <LOWER>; };
 
 // Functions & Keypad (Horizontal Combos)
 // -------------------------------------------------------------

--- a/config/boards/shields/pbgherkin/pbgherkin.keymap
+++ b/config/boards/shields/pbgherkin/pbgherkin.keymap
@@ -42,7 +42,7 @@
 
 &sk {
     release-after-ms = <2000>;
-}
+};
 
 &caps_word {
     continue-list = <UNDERSCORE BACKSPACE DELETE MINUS DOT>;

--- a/config/boards/shields/pbgherkin/pbgherkin.keymap
+++ b/config/boards/shields/pbgherkin/pbgherkin.keymap
@@ -231,7 +231,7 @@
 // -------------------------------------------------------------
             bindings = <
     &kp CARET   &kp PRCNT   &kp PLUS    &kp LBKT    &kp COMMA   &kp SEMI    &kp RBKT    &kp EXCL    &kp TILDE   &kp GRAVE
-    &kp DLLR    &kp EQUAL   &kp MINUS   &kp LPAR    &kp LT      &kp QT      &kp RPAR    &kp UNDER   &kp DQT     &kp SQT
+    &kp DLLR    &kp EQUAL   &kp MINUS   &kp LPAR    &kp LT      &kp GT      &kp RPAR    &kp UNDER   &kp DQT     &kp SQT
     &kp AT      &kp PIPE    &kp AMPS    &kp LBRC    &trans      &kp QMARK   &trans      &kp STAR    &kp HASH    &kp BSLH
             >;
         };

--- a/config/boards/shields/pbgherkin/pbgherkin.keymap
+++ b/config/boards/shields/pbgherkin/pbgherkin.keymap
@@ -14,7 +14,7 @@
 #define BASE  0     // alphas (Colemak-DH)
 #define QWRTY 1     // alphas (Qwerty)
 #define HNSDN 2     // alphas (Hands Down Neu 30)
-$define SEMMK 3     // alphas (Semimak JQ)
+#define SEMMK 3     // alphas (Semimak JQ)
 #define RAISE 4     // symbols & numbers
 #define SYMBL 5     // symbols
 #define LOWER 6     // functions & navigation


### PR DESCRIPTION
Update keymap to be compatible with 34-key no mod-tap layout used on other keyboards.
Since there is no dedicated LOWER/RAISE keys, D and H are mod-tap keys.  But Shift and Space remain single function keys.

Semimak layout is also added.